### PR TITLE
add games options: all, integer to limit total returned, and before a…

### DIFF
--- a/commands/group/games.js
+++ b/commands/group/games.js
@@ -32,7 +32,7 @@ module.exports = class GamesCommand extends Command {
   async run(msg, { options }) {
     console.log(msg)
     console.log(options)
-    const json = await api.postAction({ action: 'list_gaming_sessions', msg: msg })
+    const json = await api.postAction({ action: 'list_gaming_sessions', msg: msg, body: { options } })
     console.log(json)
 
     msg.say(json.text);

--- a/commands/group/games.js
+++ b/commands/group/games.js
@@ -16,12 +16,23 @@ module.exports = class GamesCommand extends Command {
       throttling: {
         usages: 2,
         duration: 60
-      }
+      },
+      args: [
+        {
+          key: "options",
+          prompt:
+            "Type 'all' for all games, and optionally a number to limit games returned.",
+          type: "string",
+          default: "group"
+        }
+      ]
     });
   }
 
-  async run(msg) {
-    const json = await api.postAction({ action: 'list_gaming_sessions', msg: msg, body: {} })
+  async run(msg, { options }) {
+    console.log(msg)
+    console.log(options)
+    const json = await api.postAction({ action: 'list_gaming_sessions', msg: msg })
     console.log(json)
 
     msg.say(json.text);


### PR DESCRIPTION
Add !games command options: 
- "all" to include alliance games (default is "group" for only group games)
- integer to limit total returned,
- "before xyz" and "after xyz" parses xyz using https://github.com/mojombo/chronic to return only games before or after those dates
- weekday such as "friday" or "this week" to return games for upcoming friday or this week