### PR TITLE
v14 polish: defer slow interactions, fix welcome handler, ephemeral flags

### DIFF
--- a/commands/create.js
+++ b/commands/create.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require("discord.js");
+const { SlashCommandBuilder, MessageFlags } = require("discord.js");
 const Api = require("../utils/api");
 const api = new Api();
 const DiscordApi = require("../utils/discordApi");
@@ -18,6 +18,12 @@ module.exports = {
     // console.log("VALUE:");
     // console.log(value);
 
+    // BOT-5: already deferred here pre-fix -- this command's execute path
+    // does several rails API round-trips, so this defer was correctly in
+    // place already. Left as non-ephemeral: the eventual outcome is a
+    // public gaming-session embed (channel.send), only the error followUp
+    // below needs to be ephemeral, and followUp can set that independently
+    // of the original defer.
     await interaction.deferReply();
 
     let game = interaction.options.getString("game");
@@ -179,7 +185,7 @@ module.exports = {
     if (notice.includes("Gaming Session Created!")) {
       discordApi.embedGamingSessionWithReactions(interaction, gaming_session);
     } else {
-      return interaction.followUp({ content: notice, ephemeral: true });
+      return interaction.followUp({ content: notice, flags: MessageFlags.Ephemeral });
     }
     // } catch (e) {
     //   console.log(e);

--- a/commands/createshort.js
+++ b/commands/createshort.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, ChannelType } = require("discord.js");
+const { SlashCommandBuilder, ChannelType, MessageFlags } = require("discord.js");
 const Api = require("../utils/api");
 const api = new Api();
 const DiscordApi = require("../utils/discordApi");
@@ -11,17 +11,31 @@ module.exports = {
     .setDescription("Quickly create a simple event!")
     .addStringOption((option) => option.setName("input").setDescription("event name and when it starts.")),
   async execute(interaction) {
+    // BOT-5: this command's happy path round-trips to the rails API
+    // (create_gaming_session_simple), which can exceed Discord's 3-second
+    // interaction-ack window -- the exact failure reproduced live on /c.
+    // Defer immediately, before any branching, so every path below has the
+    // ~15 minute editReply/followUp window instead of the 3s reply window.
+    // Deferred ephemeral: the actual session card is posted publicly via
+    // discordApi.embedGamingSessionWithReactions -> channel.send, which is
+    // NOT the interaction reply, so it's unaffected by this; only the small
+    // interaction-tied confirmation/help/error texts are ephemeral, which
+    // preserves (and makes consistent) the ephemeral error case from the
+    // original code.
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const value = interaction.options.getString("input");
 
     if (!value || value == "none") {
-      await interaction.reply("Help:");
       const helpEmbed = await discordApi.helpEmbed(interaction, "", "");
-      return await interaction.channel.send({ embeds: [helpEmbed] });
+      return await interaction.editReply({ content: "Help:", embeds: [helpEmbed] });
     }
 
     // return if user is in a DM channel
     if (interaction.channel?.type === ChannelType.DM) {
-      return interaction.author.send(
+      // (was `interaction.author.send(...)` -- interaction has no `.author`,
+      // only `.user`; that would have thrown on this exact path.)
+      return interaction.editReply(
         "Gaming sessions can only be created in public channels, but if you want to create a totally private gaming session you can use our website: <https://www.the100.io/gaming_sessions/new>."
       );
     }
@@ -31,7 +45,7 @@ module.exports = {
     if (!results || results.length == 0) {
       const helpEmbed = await discordApi.helpEmbed(interaction, "", "");
 
-      return await interaction.reply({
+      return await interaction.editReply({
         content: "I couldn't understand your input. Try writing it like 'apex legends tomorrow at 3pm'",
         embeds: [helpEmbed],
       });
@@ -55,9 +69,9 @@ module.exports = {
     const { notice, gaming_session } = json;
     if (notice.includes("Gaming Session Created!")) {
       discordApi.embedGamingSessionWithReactions(interaction, gaming_session);
-      interaction.reply("Gaming session created!");
+      await interaction.editReply("Gaming session created!");
     } else {
-      await interaction.reply({ content: notice, ephemeral: true });
+      await interaction.editReply({ content: notice });
     }
     // } catch (e) {
     //   console.log(e);

--- a/commands/delete.js
+++ b/commands/delete.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require("discord.js");
+const { SlashCommandBuilder, MessageFlags } = require("discord.js");
 const Api = require("../utils/api");
 const api = new Api();
 
@@ -9,6 +9,11 @@ module.exports = {
     .addStringOption((option) => option.setName("id").setDescription("The id of the game to delete").setRequired(true)),
 
   async execute(interaction) {
+    // BOT-5: postAction round-trips to the rails API and can exceed the 3s
+    // interaction window. Every reply in this command was already
+    // ephemeral, so deferring ephemeral up front preserves that exactly.
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const gaming_session_id = interaction.options.getString("id");
 
     const json = await api.postAction({
@@ -20,12 +25,12 @@ module.exports = {
 
     const substrings = ["Gaming session deleted"];
     if (substrings.some((v) => notice.includes(v))) {
-      await interaction.reply({ content: "Gaming session deleted.", ephemeral: true });
+      await interaction.editReply({ content: "Gaming session deleted." });
     } else {
       console.log("DELETE ERROR:");
       console.log(notice);
       console.log(interaction);
-      await interaction.reply({ content: notice, ephemeral: true });
+      await interaction.editReply({ content: notice });
     }
   },
 };

--- a/commands/games.js
+++ b/commands/games.js
@@ -7,9 +7,14 @@ const discordApi = new DiscordApi();
 module.exports = {
   data: new SlashCommandBuilder().setName("games").setDescription("Returns a list of upcoming group gaming sessions."),
   async execute(interaction) {
+    // BOT-5: postAction round-trips to the rails API and can exceed the 3s
+    // interaction window. Original reply was public (not ephemeral), so
+    // defer public too.
+    await interaction.deferReply();
+
     const json = await api.postAction({ action: "list_gaming_sessions", interaction: interaction, body: {} });
 
-    interaction.reply(json.text);
+    await interaction.editReply(json.text);
 
     if (!json.attachments || !json.attachments.length) {
       // No upcoming games

--- a/commands/join.js
+++ b/commands/join.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require("discord.js");
+const { SlashCommandBuilder, MessageFlags } = require("discord.js");
 const Api = require("../utils/api");
 const api = new Api();
 
@@ -9,6 +9,11 @@ module.exports = {
     .addStringOption((option) => option.setName("id").setDescription("The id of the game to join").setRequired(true)),
 
   async execute(interaction) {
+    // BOT-5: postAction round-trips to the rails API and can exceed the 3s
+    // interaction window. Every reply in this command was already
+    // ephemeral, so deferring ephemeral up front preserves that exactly.
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const gaming_session_id = interaction.options.getString("id");
 
     let reserve = false;
@@ -24,12 +29,12 @@ module.exports = {
 
     const substrings = ["reserve", "waitlist", "You just joined"];
     if (substrings.some((v) => notice.includes(v))) {
-      await interaction.reply({ content: "Game Joined!", ephemeral: true });
+      await interaction.editReply({ content: "Game Joined!" });
     } else {
       console.log("JOIN ERROR:");
       console.log(notice);
       console.log(interaction);
-      await interaction.reply({ content: notice, ephemeral: true });
+      await interaction.editReply({ content: notice });
     }
   },
 };

--- a/commands/leave.js
+++ b/commands/leave.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder } = require("discord.js");
+const { SlashCommandBuilder, MessageFlags } = require("discord.js");
 const Api = require("../utils/api");
 const api = new Api();
 
@@ -9,6 +9,11 @@ module.exports = {
     .addStringOption((option) => option.setName("id").setDescription("The id of the game to leave").setRequired(true)),
 
   async execute(interaction) {
+    // BOT-5: postAction round-trips to the rails API and can exceed the 3s
+    // interaction window. Every reply in this command was already
+    // ephemeral, so deferring ephemeral up front preserves that exactly.
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const gaming_session_id = interaction.options.getString("id");
 
     let reserve = false;
@@ -24,12 +29,12 @@ module.exports = {
 
     const substrings = ["Game left"];
     if (substrings.some((v) => notice.includes(v))) {
-      await interaction.reply({ content: "Game left.", ephemeral: true });
+      await interaction.editReply({ content: "Game left." });
     } else {
       console.log("LEAVE ERROR:");
       console.log(notice);
       console.log(interaction);
-      await interaction.reply({ content: notice, ephemeral: true });
+      await interaction.editReply({ content: notice });
     }
   },
 };

--- a/commands/link.js
+++ b/commands/link.js
@@ -1,14 +1,28 @@
-const { SlashCommandBuilder } = require("discord.js");
+const { SlashCommandBuilder, MessageFlags } = require("discord.js");
 
 module.exports = {
   data: new SlashCommandBuilder().setName("link").setDescription("Link your The100.io account."),
   async execute(interaction) {
+    // BOT-5: no rails API call here, but sending the DM is itself a Discord
+    // API round-trip that can be slow (or reject, e.g. DMs closed) --
+    // deferring keeps this command in the same safe pattern as the rest.
+    // Original reply was ephemeral, so defer ephemeral up front.
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
     const guildId = interaction.guild ? encodeURIComponent(interaction.guild.id) : "";
     const baseUrl = process.env.THE100_BASE_URL || "https://www.the100.io/";
     const content = `Click here to link your account: <${baseUrl}linkdiscord/${encodeURIComponent(
       interaction.user.id
     )}/${encodeURIComponent(interaction.user.username)}?guild_id=${guildId}>`;
-    await interaction.user.send(content);
-    return interaction.reply({ content: "Check your DMs for a link!", ephemeral: true });
+    try {
+      await interaction.user.send(content);
+      return interaction.editReply({ content: "Check your DMs for a link!" });
+    } catch (e) {
+      console.log("LINK DM ERROR: ");
+      console.log(e);
+      return interaction.editReply({
+        content: "I couldn't send you a DM -- check your privacy settings allow DMs from server members, then try again.",
+      });
+    }
   },
 };

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,4 +1,4 @@
-const { PermissionsBitField } = require("discord.js");
+const { PermissionsBitField, MessageFlags } = require("discord.js");
 const Api = require("../utils/api");
 const api = new Api();
 const DiscordApi = require("../utils/discordApi");
@@ -52,7 +52,10 @@ module.exports = {
       } else {
         console.log("interactionCreate.js ERROR:");
         console.log(notice);
-        await interaction.reply({ content: notice ? notice : "An error ocurred, please contact us.", ephemeral: true });
+        await interaction.reply({
+          content: notice ? notice : "An error ocurred, please contact us.",
+          flags: MessageFlags.Ephemeral,
+        });
       }
     } catch (error) {
       sendError(error, interaction);

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,14 +1,36 @@
-const { PermissionsBitField, MessageFlags } = require("discord.js");
+const { PermissionsBitField } = require("discord.js");
 const Api = require("../utils/api");
 const api = new Api();
 const DiscordApi = require("../utils/discordApi");
 const discordApi = new DiscordApi();
+// This handler is a component (button) interaction, not a slash command --
+// its eventual "response" is an edit of the original gaming-session embed,
+// not a throwaway placeholder. respondAuxiliary never uses editReply (which
+// would clobber that embed with plain error text); it always opens a new
+// ephemeral followUp once the interaction has been acknowledged in any way.
+// See utils/interactionResponder.js.
+const { respondAuxiliary } = require("../utils/interactionResponder");
 
 module.exports = {
   name: "interactionCreate",
   async execute(interaction) {
     try {
       if (!interaction.isButton()) return;
+
+      // BOT-5 (button flavor): api.postReaction below round-trips to the
+      // rails API and can exceed Discord's 3s interaction-ack window, same
+      // class of bug as the slash commands. For a component interaction
+      // whose eventual outcome is editing the original message in place,
+      // the correct immediate ack is deferUpdate() (not deferReply()/
+      // reply()) -- it acknowledges the click with no visible "thinking"
+      // state and no new message, and lets us edit the original message
+      // later via editReply() instead of the no-longer-valid
+      // interaction.update(). This keeps the end-state UX identical to
+      // before: the join/leave/refresh still lands as an in-place edit of
+      // the same embed, just acknowledged up front instead of after the
+      // API call.
+      await interaction.deferUpdate();
+
       console.log(
         `${interaction.user.tag} in #${interaction.channel.name} triggered an interaction in interactionCreate.js.`
       );
@@ -47,15 +69,16 @@ module.exports = {
       if (gaming_session || (notice && substrings.some((v) => notice.includes(v)))) {
         const receivedEmbed = interaction.message.embeds[0];
         const exampleEmbed = await discordApi.embedGamingSessionDynamic(gaming_session, receivedEmbed);
-        await interaction.update({ embeds: [exampleEmbed] });
+        // Already deferred via deferUpdate() above, so editReply() (not
+        // update(), which is no longer valid once acknowledged) edits the
+        // original message -- identical end result to the old
+        // interaction.update() call.
+        await interaction.editReply({ embeds: [exampleEmbed] });
         return;
       } else {
         console.log("interactionCreate.js ERROR:");
         console.log(notice);
-        await interaction.reply({
-          content: notice ? notice : "An error ocurred, please contact us.",
-          flags: MessageFlags.Ephemeral,
-        });
+        await respondAuxiliary(interaction, notice ? notice : "An error ocurred, please contact us.");
       }
     } catch (error) {
       sendError(error, interaction);
@@ -68,21 +91,52 @@ const sendError = async (error, interaction) => {
     console.error(error);
     console.log(interaction);
     const permissions = interaction.channel?.permissionsFor(interaction.client.user);
-    interaction.client.users.cache
-      .get(process.env.OWNER_DISCORD_ID)
-      ?.send(
-        `Error for command: **${interaction.customId}** with proper permissions: **${permissions?.has(
-          PermissionsBitField.Flags.ManageMessages
-        )}** in channel ${interaction.channel} in guild ${interaction.guild?.name} - ${interaction.guild} from user ${
-          interaction.user
-        } - ${interaction.user?.id}`
-      );
 
-    interaction.client.users.cache.get(process.env.OWNER_DISCORD_ID)?.send(error.toString());
+    // Owner DM report. Best-effort: never let a failure here (e.g. owner
+    // has DMs closed) escape and crash the process -- report-only side
+    // effect, not user-facing.
+    try {
+      interaction.client.users.cache
+        .get(process.env.OWNER_DISCORD_ID)
+        ?.send(
+          `Error for command: **${interaction.customId}** with proper permissions: **${permissions?.has(
+            PermissionsBitField.Flags.ManageMessages
+          )}** in channel ${interaction.channel} in guild ${interaction.guild?.name} - ${interaction.guild} from user ${
+            interaction.user
+          } - ${interaction.user?.id}`
+        );
 
-    await interaction.channel?.send(
-      "There was an error while executing this command - the developers have been notified and you can also contact us in our support discord: https://discord.gg/EFRQxvUGM6"
-    );
+      interaction.client.users.cache.get(process.env.OWNER_DISCORD_ID)?.send(error.toString());
+    } catch (ownerReportError) {
+      console.log("sendError OWNER REPORT ERROR: ");
+      console.log(ownerReportError);
+    }
+
+    // User-facing notice. By the time execute() throws, the interaction has
+    // normally already been deferUpdate()'d (BOT-5, see above) -- route
+    // through respondAuxiliary so we open a fresh ephemeral followUp
+    // instead of a bare interaction.reply() (which would throw: already
+    // acknowledged) or an editReply() (which would clobber the original
+    // gaming-session embed with plain error text). Fall back to a plain
+    // channel message if even that fails (e.g. token fully expired).
+    const message =
+      "There was an error while executing this command - the developers have been notified and you can also contact us in our support discord: https://discord.gg/EFRQxvUGM6";
+    try {
+      if (typeof interaction?.reply === "function") {
+        await respondAuxiliary(interaction, message);
+      } else {
+        await interaction.channel?.send(message);
+      }
+    } catch (replyError) {
+      console.log("sendError REPLY ERROR, falling back to channel.send: ");
+      console.log(replyError);
+      try {
+        await interaction.channel?.send(message);
+      } catch (channelSendError) {
+        console.log("sendError CHANNEL SEND ERROR: ");
+        console.log(channelSendError);
+      }
+    }
   } catch (error) {
     console.error(error);
   }

--- a/events/welcome.js
+++ b/events/welcome.js
@@ -32,11 +32,29 @@ module.exports = (client) => {
   });
 
   // get all the members with manage server permissions
-  client.on("messageCreate", async (guild) => {
+  //
+  // BOT-1 root cause: this handler was wired to the "messageCreate" event
+  // while treating its callback argument as a Guild (naming it `guild` and
+  // calling `guild.members.cache`, copy-pasted from the guildCreate handler
+  // above). messageCreate's argument is a Message, which has no `.members`
+  // property at all -- so `guild.members` was always undefined and
+  // `.cache` threw "Cannot read properties of undefined (reading 'cache')"
+  // on literally every message the bot could see, including DMs (which
+  // also have no `.guild`). See DISCORD_BOT_ENGAGEMENT_PLAN.md BOT-1.
+  //
+  // Fix: this is clearly a "DM the admins when the bot joins a server"
+  // flow (matches the comment and the sibling handler above it), so it
+  // belongs on guildCreate, not on every message. That also removes an
+  // unintentional spam vector the crash had been accidentally masking
+  // (DMing every server admin on every single chat message). A defensive
+  // guard is kept in case a partial/unavailable guild object ever reaches
+  // here without a populated members cache.
+  client.on("guildCreate", async (guild) => {
     try {
       console.log("STARTING SENDING WELCOME DM TO MANAGERS");
 
-      // const guild = client.guilds.cache.get(process.env.GUILD_ID);
+      if (!guild?.members?.cache) return;
+
       const members = guild.members.cache.filter((member) =>
         member.permissions.has(PermissionsBitField.Flags.Administrator)
       );
@@ -53,7 +71,14 @@ module.exports = (client) => {
           .setThumbnail(client.user.avatarURL())
           .setTimestamp();
         console.log("SENDING WELCOME DM TO MANAGERS");
-        await member.send({ embeds: [embed] });
+        try {
+          await member.send({ embeds: [embed] });
+        } catch (e) {
+          // Member has DMs closed / blocked the bot -- not fatal, don't let
+          // one rejection inside this forEach take down the rest.
+          console.log("WELCOME DM ERROR (member likely has DMs closed): ");
+          console.log(e);
+        }
       });
     } catch (e) {
       console.log(e);

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const {
   Client,
   Collection,
   GatewayIntentBits,
+  MessageFlags,
   Partials,
   PermissionsBitField,
 } = require("discord.js");
@@ -101,21 +102,56 @@ const sendError = async (error, interaction) => {
     console.log("START SEND ERROR");
     console.error(error);
     const permissions = interaction.channel?.permissionsFor(client.user);
-    client.users.cache
-      .get(process.env.OWNER_DISCORD_ID)
-      ?.send(
-        `Error for command: **${interaction.commandName}** with proper permissions: **${permissions?.has(
-          PermissionsBitField.Flags.ManageMessages
-        )}** in channel ${interaction.channel} in guild ${interaction.guild?.name} - ${interaction.guild} from user ${
-          interaction.user
-        } - ${interaction.user?.id}`
-      );
 
-    client.users.cache.get(process.env.OWNER_DISCORD_ID)?.send(error.toString());
+    // Owner DM report. Best-effort: never let a failure here (e.g. owner
+    // has DMs closed, or client.users.cache miss) escape and crash the
+    // process -- these are report-only side effects, not user-facing.
+    try {
+      client.users.cache
+        .get(process.env.OWNER_DISCORD_ID)
+        ?.send(
+          `Error for command: **${interaction.commandName}** with proper permissions: **${permissions?.has(
+            PermissionsBitField.Flags.ManageMessages
+          )}** in channel ${interaction.channel} in guild ${interaction.guild?.name} - ${interaction.guild} from user ${
+            interaction.user
+          } - ${interaction.user?.id}`
+        );
 
-    await interaction.channel?.send(
-      "There was an error while executing this command - the developers have been notified and you can also contact us in our support discord: https://discord.gg/EFRQxvUGM6"
-    );
+      client.users.cache.get(process.env.OWNER_DISCORD_ID)?.send(error.toString());
+    } catch (ownerReportError) {
+      console.log("sendError OWNER REPORT ERROR: ");
+      console.log(ownerReportError);
+    }
+
+    // User-facing notice. The command's own execute() may have already
+    // deferred/replied to the interaction before it blew up (BOT-5), so a
+    // bare interaction.reply() here can itself throw (already
+    // acknowledged, or the interaction token already expired). Route
+    // through whichever response method matches the interaction's actual
+    // state, and fall back to a plain channel message if even that fails
+    // (e.g. token fully expired) rather than letting the error propagate.
+    const message =
+      "There was an error while executing this command - the developers have been notified and you can also contact us in our support discord: https://discord.gg/EFRQxvUGM6";
+    try {
+      if (interaction?.replied) {
+        await interaction.followUp({ content: message, flags: MessageFlags.Ephemeral });
+      } else if (interaction?.deferred) {
+        await interaction.editReply({ content: message });
+      } else if (typeof interaction?.reply === "function") {
+        await interaction.reply({ content: message, flags: MessageFlags.Ephemeral });
+      } else {
+        await interaction.channel?.send(message);
+      }
+    } catch (replyError) {
+      console.log("sendError REPLY ERROR, falling back to channel.send: ");
+      console.log(replyError);
+      try {
+        await interaction.channel?.send(message);
+      } catch (channelSendError) {
+        console.log("sendError CHANNEL SEND ERROR: ");
+        console.log(channelSendError);
+      }
+    }
   } catch (e) {
     console.log("sendError ERROR: ");
     console.log(e);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const {
   Client,
   Collection,
   GatewayIntentBits,
-  MessageFlags,
   Partials,
   PermissionsBitField,
 } = require("discord.js");
@@ -15,6 +14,11 @@ const Api = require("./utils/api");
 const api = new Api();
 const DiscordApi = require("./utils/discordApi");
 const discordApi = new DiscordApi();
+// This handler only ever fires for slash commands (isChatInputCommand),
+// which all defer via deferReply -- so the single-deferred-placeholder
+// semantics of respondToPrimary are the right fit here. See
+// utils/interactionResponder.js.
+const { respondToPrimary } = require("./utils/interactionResponder");
 
 // Function-style event modules (module.exports = (client) => {...}). These are
 // wired explicitly below rather than through the events/ auto-loader, which
@@ -133,12 +137,8 @@ const sendError = async (error, interaction) => {
     const message =
       "There was an error while executing this command - the developers have been notified and you can also contact us in our support discord: https://discord.gg/EFRQxvUGM6";
     try {
-      if (interaction?.replied) {
-        await interaction.followUp({ content: message, flags: MessageFlags.Ephemeral });
-      } else if (interaction?.deferred) {
-        await interaction.editReply({ content: message });
-      } else if (typeof interaction?.reply === "function") {
-        await interaction.reply({ content: message, flags: MessageFlags.Ephemeral });
+      if (typeof interaction?.reply === "function") {
+        await respondToPrimary(interaction, message);
       } else {
         await interaction.channel?.send(message);
       }

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,5 +1,29 @@
 // Uses the global fetch built into Node 18+ (no node-fetch dependency needed).
 
+const { MessageFlags } = require("discord.js");
+
+// Slash commands that hit this API defer their reply before calling
+// postAction (BOT-5), so by the time an error status comes back the
+// interaction is usually already deferred (occasionally already replied, if
+// an earlier step in the command sent something first). A bare
+// `interaction.reply(...)` here throws once the interaction has already been
+// acknowledged. Pick the response method that matches whatever state the
+// interaction is actually in.
+const respondToInteraction = async (interaction, content) => {
+  try {
+    if (interaction.replied) {
+      return await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+    }
+    if (interaction.deferred) {
+      return await interaction.editReply({ content });
+    }
+    return await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+  } catch (e) {
+    console.log("respondToInteraction ERROR: ");
+    console.log(e);
+  }
+};
+
 module.exports = class Api {
   async post(url, data) {
     console.log("LINK: ");
@@ -40,11 +64,13 @@ module.exports = class Api {
     console.log(res);
 
     if (res.status == 404 || res.status == 401) {
-      return interaction.reply(
+      return respondToInteraction(
+        interaction,
         "Error: No The100.io group found. Go to <https://www.the100.io/groups/new> to re-add this bot from your group page."
       );
     } else if (res.status !== 201) {
-      return interaction.reply(
+      return respondToInteraction(
+        interaction,
         "Error: Contact Us at: <https://www.the100.io/help> or: <https://discord.gg/FTDeeXA> for help."
       );
     }
@@ -73,15 +99,17 @@ module.exports = class Api {
 
     const res = await this.post(url, data);
     if (res.status == 404) {
+      // Note: `ephemeral` is not a valid MessageCreateOptions field (this is
+      // a plain channel.send, not an interaction reply) -- it was a no-op.
+      // Dropped rather than "fixed" since a plain channel message can't be
+      // ephemeral at all.
       return msg.channel.send({
         content:
           "Error: No The100.io group found. Go to <https://www.the100.io> to re-add this bot from your group page.",
-        ephemeral: true,
       });
     } else if (res.status !== 201) {
       return msg.channel.send({
         content: "Error: Contact Us at: <https://www.the100.io/help> or: <https://discord.gg/FTDeeXA> for help.",
-        ephemeral: true,
       });
     }
     return await res.json();

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,23 +1,18 @@
 // Uses the global fetch built into Node 18+ (no node-fetch dependency needed).
 
-const { MessageFlags } = require("discord.js");
+const { respondToPrimary } = require("./interactionResponder");
 
 // Slash commands that hit this API defer their reply before calling
 // postAction (BOT-5), so by the time an error status comes back the
 // interaction is usually already deferred (occasionally already replied, if
 // an earlier step in the command sent something first). A bare
 // `interaction.reply(...)` here throws once the interaction has already been
-// acknowledged. Pick the response method that matches whatever state the
-// interaction is actually in.
+// acknowledged. respondToPrimary picks the response method that matches
+// whatever state the interaction is actually in -- see
+// utils/interactionResponder.js.
 const respondToInteraction = async (interaction, content) => {
   try {
-    if (interaction.replied) {
-      return await interaction.followUp({ content, flags: MessageFlags.Ephemeral });
-    }
-    if (interaction.deferred) {
-      return await interaction.editReply({ content });
-    }
-    return await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+    return await respondToPrimary(interaction, content);
   } catch (e) {
     console.log("respondToInteraction ERROR: ");
     console.log(e);

--- a/utils/interactionResponder.js
+++ b/utils/interactionResponder.js
@@ -1,0 +1,44 @@
+// Shared "pick the right discord.js response method" logic (BOT-5) for
+// interactions that may already be deferred/replied by the time we need to
+// say something -- e.g. after an await on the rails API. Two flavors,
+// because deferReply vs deferUpdate mean different things for what
+// editReply will touch:
+//
+//   respondToPrimary  - for interactions whose single deferred response
+//     *is* the whole answer (slash commands: deferReply(), then one
+//     editReply() with the final text). Reuses/finalizes that placeholder.
+//     If the interaction has moved on and already replied once, falls back
+//     to a followUp so we don't try to edit a response a second caller
+//     already finalized.
+//
+//   respondAuxiliary - for interactions where editReply would clobber
+//     something we don't want to touch (a button's deferUpdate() targets
+//     the original embed/card, not a throwaway placeholder). Always sends
+//     a *new* ephemeral message via followUp once the interaction has been
+//     acknowledged in any way, and only falls back to a bare reply if the
+//     interaction is still fully unacknowledged.
+//
+// Both are best-effort: if discord.js itself throws (token fully expired,
+// double-ack race, etc.) the caller gets the rejection and should treat it
+// the same as any other failed notification -- log it, don't crash.
+
+const { MessageFlags } = require("discord.js");
+
+async function respondToPrimary(interaction, content) {
+  if (interaction.replied) {
+    return interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+  }
+  if (interaction.deferred) {
+    return interaction.editReply({ content });
+  }
+  return interaction.reply({ content, flags: MessageFlags.Ephemeral });
+}
+
+async function respondAuxiliary(interaction, content) {
+  if (interaction.replied || interaction.deferred) {
+    return interaction.followUp({ content, flags: MessageFlags.Ephemeral });
+  }
+  return interaction.reply({ content, flags: MessageFlags.Ephemeral });
+}
+
+module.exports = { respondToPrimary, respondAuxiliary };


### PR DESCRIPTION
Fixes BOT-1, BOT-3, BOT-5 from `DISCORD_BOT_ENGAGEMENT_PLAN.md` §5 (bot-side gaps found during live test 2026-07-23).

## BOT-5 — interaction-token timeouts on slow commands (highest value)

Commands whose execute path round-trips to the rails API (`utils/api.js`) can exceed Discord's 3-second interaction-ack window. When that happens, `interaction.reply(...)` throws `DiscordAPIError[10062] Unknown interaction` even though the operation succeeded server-side — reproduced live today on `/c`.

Fixed by deferring immediately in every command whose path does an API call or other non-trivial async work, then converting the first reply to `editReply` and any subsequent one to `followUp`:

- `commands/createshort.js` (`/c`) — no defer before; the exact command that failed live. Also fixed an incidental bug found while rewiring this exact line: the DM-channel-restriction path called `interaction.author.send(...)`, but interactions have no `.author`, only `.user` — would have thrown.
- `commands/create.js` (`/create`) — already had `deferReply()` in place; only needed the BOT-3 ephemeral fix.
- `commands/join.js`, `commands/leave.js`, `commands/delete.js` — added `deferReply({ flags: MessageFlags.Ephemeral })` (every reply in these was already ephemeral, so this preserves that exactly) + `editReply`.
- `commands/games.js` (`/games`) — added `deferReply()` (public, matches original) + `editReply`.
- `commands/link.js` (`/link`) — added `deferReply({ flags: MessageFlags.Ephemeral })`; the DM send itself is a Discord API round trip that can be slow or reject (DMs closed), so wrapped it in try/catch with a friendlier failure message.

**Deliberately skipped** (audited, no change needed):
- `commands/count.js` — pure local (`interaction.client.guilds.cache.size`), no API call.
- `commands/help.js` — pure local text/embed, no API call.
- `commands/status.js` (`/the100status`) — already immune: it calls `interaction.reply("Online!")` *before* the slow API call, then `editReply`s after. That pattern was already correct.

Also hardened the shared plumbing that every one of these commands funnels through:
- `utils/api.js`'s `postAction` had its own hardcoded `interaction.reply(...)` on API-error responses (404/401/other non-201). Once commands defer first, that bare `reply` would itself throw (already acknowledged). Added a `respondToInteraction` helper that checks `interaction.replied` / `interaction.deferred` and picks `followUp` / `editReply` / `reply` accordingly.
- `index.js`'s global error handler (`sendError`, ~line 89) had the same problem for the catch-all path, plus no protection around the owner-DM report. Wrapped the owner-DM report so a failed report can never crash the process, and made the user-facing error message route through `followUp`/`editReply`/`reply` based on interaction state, falling back to a plain `channel.send` if even that fails (e.g. token fully expired).

## BOT-1 — `events/welcome.js:40` TypeError

Root cause: the admin-DM handler was registered on `client.on("messageCreate", async (guild) => {...})` while its body treated the callback argument as a `Guild` (`guild.members.cache...`) — almost certainly copy-pasted from the `guildCreate` handler directly above it. A `Message` object has no `.members` property at all, so this threw `Cannot read properties of undefined (reading 'cache')` on *every single message* the bot could see, including DMs (which also have no `.guild`) — matching what showed up in today's live logs.

Fix: rewired the handler to `guildCreate` (matches its actual intent — "DM the admins when the bot joins a server" — and its own comments), added a defensive `if (!guild?.members?.cache) return;` guard for any partial/unavailable guild object, and wrapped the per-member `member.send(...)` in its own try/catch (an async rejection inside a `.forEach` callback wasn't actually caught by the outer try/catch before). This incidentally also removes an unintentional spam vector the crash had been masking: DMing every server admin on every single chat message.

## BOT-3 — deprecated `ephemeral` option

Replaced every `ephemeral: true` with `flags: MessageFlags.Ephemeral` (imported from `discord.js`) across all the commands touched above, `utils/api.js`, and `events/interactionCreate.js` (the button-click handler for Join/Leave/Refresh). Also dropped two dead `ephemeral: true` keys on plain `msg.channel.send(...)` calls in `postReaction` — not a valid option there, was always a silent no-op.

## Verification (no real login, per the task's constraints — production dyno is live)

1. `node --check` on every touched file — all pass.
2. Booted with **no `.env` present** (worktree deliberately has no env file symlinked): `node index.js` reaches a clean `DiscordjsError [TokenInvalid]: An invalid token was provided.` and exits — proves every module, command, and event file loads and wires correctly; nothing else in the boot path is broken.
3. `GUILD_ID=x CLIENT_ID=x DISCORD_BOT_TOKEN=x node deploy-commands.js` logs "Started refreshing 10 application (/) commands" then fails with `DiscordAPIError[0]: 401: Unauthorized` — fails at the Discord API auth stage, not at module load, confirming `command.data.toJSON()` works for all 10 commands.
4. Grepped the whole tree for `ephemeral` — zero remaining `ephemeral:` reply/defer options (only comments referencing the word). Grepped `commands/*.js` for stray `interaction.reply(` — only the three deliberately-undeferred commands (`count`, `help`, `status`) remain.
5. `eslint` over the touched files shows the same 29 pre-existing errors present on the unmodified `master` checkout (unused vars, `no-shadow`, `prefer-const`, etc.) — confirmed no new lint errors were introduced.

Not run (per instructions): no real Discord login, no Heroku commands, no merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)